### PR TITLE
Logrotate для xray + защита от ботов на :10443 + no-referrer для подписки

### DIFF
--- a/autoXRAY1.sh
+++ b/autoXRAY1.sh
@@ -58,6 +58,38 @@ ulimit -n 65535
 echo -e "${GRN}Лимиты применены. Текущий ulimit -n: $(ulimit -n) ${NC}"
 
 
+# Ротация логов xray (защита от роста /var/log/xray)
+if ! command -v logrotate >/dev/null 2>&1; then
+    apt-get install -y logrotate
+fi
+
+mkdir -p /var/log/xray
+cat <<'EOF' > /etc/logrotate.d/xray
+/var/log/xray/*.log {
+    daily
+    rotate 7
+    size 10M
+    missingok
+    notifempty
+    compress
+    delaycompress
+    copytruncate
+    sharedscripts
+    su root root
+    create 0640 root root
+}
+EOF
+chmod 0644 /etc/logrotate.d/xray
+
+# Применить сразу + проверка синтаксиса конфига
+if logrotate -d /etc/logrotate.d/xray >/dev/null 2>&1; then
+    logrotate -f /etc/logrotate.d/xray >/dev/null 2>&1 || true
+    echo -e "${GRN}✅ Logrotate для xray установлен (/etc/logrotate.d/xray)${NC}"
+else
+    echo -e "${RED}❌ Ошибка в /etc/logrotate.d/xray${NC}"
+fi
+
+
 # Создание директории сайта
 WEB_PATH="/var/www/$DOMAIN"
 mkdir -p "$WEB_PATH"

--- a/autoXRAY1.sh
+++ b/autoXRAY1.sh
@@ -205,10 +205,19 @@ server {
     location = /${path_subpage}.json {
 		add_header profile-title "base64:YXV0b1hSQVk=";
 		add_header routing "happ://routing/onadd/eyJOYW1lIjoiYXV0b1hSQVkiLCJHbG9iYWxQcm94eSI6InRydWUiLCJSb3V0ZU9yZGVyIjoiYmxvY2stcHJveHktZGlyZWN0IiwiUmVtb3RlRE5TVHlwZSI6IkRvSCIsIlJlbW90ZUROU0RvbWFpbiI6Imh0dHBzOi8vZG5zLmdvb2dsZS9kbnMtcXVlcnkiLCJSZW1vdGVETlNJUCI6IjguOC40LjQiLCJEb21lc3RpY0ROU1R5cGUiOiJEb0giLCJEb21lc3RpY0ROU0RvbWFpbiI6Imh0dHBzOi8vY2xvdWRmbGFyZS1kbnMuY29tL2Rucy1xdWVyeSIsIkRvbWVzdGljRE5TSVAiOiIxLjEuMS4xIiwiR2VvaXB1cmwiOiJodHRwczovL2dpdGh1Yi5jb20vTG95YWxzb2xkaWVyL3YycmF5LXJ1bGVzLWRhdC9yZWxlYXNlcy9sYXRlc3QvZG93bmxvYWQvZ2VvaXAuZGF0IiwiR2Vvc2l0ZXVybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9Mb3lhbHNvbGRpZXIvdjJyYXktcnVsZXMtZGF0L3JlbGVhc2VzL2xhdGVzdC9kb3dubG9hZC9nZW9zaXRlLmRhdCIsIkxhc3RVcGRhdGVkIjoiMTc3NTIwNjEwOCIsIkRuc0hvc3RzIjp7fSwiRGlyZWN0U2l0ZXMiOlsiZ2Vvc2l0ZTpjYXRlZ29yeS1ydSIsImdlb3NpdGU6cHJpdmF0ZSJdLCJEaXJlY3RJcCI6WyJnZW9pcDpwcml2YXRlIl0sIlByb3h5U2l0ZXMiOltdLCJQcm94eUlwIjpbXSwiQmxvY2tTaXRlcyI6WyJnZW9zaXRlOmNhdGVnb3J5LWFkcyIsImdlb3NpdGU6d2luLXNweSJdLCJCbG9ja0lwIjpbXSwiRG9tYWluU3RyYXRlZ3kiOiJJUElmTm9uTWF0Y2giLCJGYWtlRE5TIjoiZmFsc2UiLCJVc2VDaHVua0ZpbGVzIjoiZmFsc2UifQ";
-		
+
 		add_header routing-enable 0;
+		add_header Referrer-Policy "no-referrer" always;
+		add_header X-Robots-Tag "noindex, nofollow, noarchive, nosnippet" always;
+		add_header Cache-Control "no-store" always;
 	}
-    
+
+    location = /${path_subpage}.html {
+        add_header Referrer-Policy "no-referrer" always;
+        add_header X-Robots-Tag "noindex, nofollow, noarchive, nosnippet" always;
+        add_header Cache-Control "no-store" always;
+    }
+
     location /${path_xhttp} {
         proxy_pass http://127.0.0.1:8400;
         proxy_http_version 1.1;
@@ -280,6 +289,21 @@ if ss -tuln | grep -q ":40000 "; then
 else
     echo -e "${GRN}Установка WARP-cli (автоматически)...${NC}"
     echo -e "1\n1\n40000" | bash <(curl -fsSL https://gitlab.com/fscarmen/warp/-/raw/main/menu.sh) w
+fi
+
+
+# Защита SOCKS5/mixed (10443) от ботов: rate-limit новых соединений на IP
+if ! command -v netfilter-persistent >/dev/null 2>&1; then
+    DEBIAN_FRONTEND=noninteractive apt-get install -y iptables-persistent
+fi
+
+RULE_10443="-p tcp --dport 10443 -m conntrack --ctstate NEW -m hashlimit --hashlimit-name socks10443 --hashlimit-above 5/minute --hashlimit-burst 10 --hashlimit-mode srcip --hashlimit-srcmask 32 -j DROP"
+if ! iptables -C INPUT $RULE_10443 2>/dev/null; then
+    iptables -I INPUT 1 $RULE_10443
+    netfilter-persistent save >/dev/null 2>&1
+    echo -e "${GRN}✅ iptables: rate-limit на 10443 (5/min, burst 10) установлен${NC}"
+else
+    echo -e "${GRN}iptables правило для 10443 уже есть${NC}"
 fi
 
 # Экспортируем переменные для envsubst


### PR DESCRIPTION
Привет! Накатил у себя три небольших улучшения скрипта `autoXRAY1.sh` — обкатал на двух production-серверах, оба здоровы. Если интересно — забирайте.

## Что меняется

### 1. Logrotate для `/var/log/xray` (коммит `38f5d25`)

Конфиг `/etc/logrotate.d/xray`: ротация ежедневная, хранение 7 дней или по достижении 10 МБ, сжатие, `copytruncate` (xray не нужно перезапускать). Без этого `access.log` и `error.log` растут неограниченно — за пару недель `/var` может раздуть на несколько ГБ.

Установка идемпотентная: проверяет наличие пакета, валидирует синтаксис через `logrotate -d` перед применением.

### 2. iptables rate-limit на SOCKS5/mixed `:10443` (коммит `bfc4d04`, часть)

В `error.log` xray постоянно сыпались малформ-запросы от сканеров (zmap, censys, MGLNDD, GET `/.env` и пр.) — за сутки тысячи строк типа:

```
[Warning] app/proxyman/inbound: connection ends > proxy/http: failed to read http request > malformed HTTP request "MGLNDD_91.227.77.79_10443"
```

Решение через iptables `hashlimit`: 5 новых соединений в минуту с одного src-IP, burst 10, превышение — DROP. Легитимный пользователь не заметит, боты обламываются. Установка ставит `iptables-persistent` если нет, сохраняет правило через `netfilter-persistent save` (переживает reboot).

Идемпотентно (`iptables -C` перед `-I`).

### 3. Защита подписочной страницы от утечки URL (коммит `bfc4d04`, часть)

На `${path_subpage}.html` и `${path_subpage}.json` добавлены три заголовка:
- `Referrer-Policy: no-referrer` — браузер не отправит `Referer` при клике на любую внешнюю ссылку (например, на ссылку GitHub в подвале страницы), URL подписки не утекает в логи внешних сайтов
- `X-Robots-Tag: noindex, nofollow, noarchive, nosnippet` — запрет индексации поисковиками
- `Cache-Control: no-store` — запрет кэширования прокси/CDN

Случайный 20-символьный путь и так от брутфорса защищает, но `Referer`-утечка через клик — реальный вектор.

## Как протестировано

- `bash -n autoXRAY1.sh` — синтаксис ОК
- Применил все три на двух серверах (Debian 13, IPv4-only):
  - `logrotate -d /etc/logrotate.d/xray` — валидно
  - `iptables -L INPUT -n -v` — правило висит, на одном из серверов уже срезало 46+ пакетов от сканеров
  - `curl -I https://<domain>/<path>.html` — три новых заголовка приходят
- VLESS Reality + XHTTP TLS + WS TLS подключения протестированы стандартным xray-client'ом и Happ — всё работает, изменения ничего не ломают

Если надо что-то поправить в стиле/структуре — скажите. Спасибо за скрипт!